### PR TITLE
Support installation per azure organization.

### DIFF
--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -20,6 +20,12 @@
       "required": true
     },
     {
+      "name": "vso_workitem_tag_prefix",
+      "type": "text",
+      "required": true,
+      "default":"vso_wi_"
+    },
+    {
       "name": "vso_tag",
       "type": "text",
       "required": false,

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "karma-phantomjs-launcher": "^1.0.4",
     "karma-webpack": "^2.0.4",
     "loader-utils": "^1.1.0",
-    "node-sass": "^4.5.3",
+    "node-sass": "^4.14.1",
     "sass-loader": "^6.0.6",
     "style-loader": "^0.18.2",
     "url-loader": "^0.5.9",

--- a/src/javascripts/app.js
+++ b/src/javascripts/app.js
@@ -485,6 +485,7 @@ const App = (function() {
                     return this.switchTo("finish_setup");
                 } //set account url
 
+                TAG_PREFIX = this.setting("vso_workitem_tag_prefix");
                 assignVm({ accountUrl: this.buildAccountUrl() });
 
                 if (!this.store("auth_token_for_" + this.setting("vso_account"))) {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -7,6 +7,10 @@
                 "helpText":
                     "Enter your Visual Studio Team Services subdomain (part before visualstudio.com). Learn more by visiting http://go.microsoft.com/fwlink/?LinkID=396756"
             },
+            "vso_workitem_tag_prefix": {
+                "label": "Workitem Tag Prefix",
+                "helpText": "When linking azure board items, tags with this prefix will be added to zendesk ticket. When using multiple azure organizations this must be distinct for each organization."
+            },
             "vso_tag": {
                 "label": "Visual Studio Team Services work item tag",
                 "helpText":


### PR DESCRIPTION
Added application setting for work item tag prefix that is used to link work item with ZenDesk ticket.
Currently this tag prefix is hardcoded to `vso_wi_` and to maintain compatibility this new setting has the same default value.